### PR TITLE
feat: openFeign 관련 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,16 @@ repositories {
 	mavenCentral()
 }
 
+ext {
+	set('springCloudVersion', "2024.0.0")
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+	}
+}
+
 dependencies {
 	// implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
@@ -34,6 +44,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 }
 
 tasks.named('test') {

--- a/src/main/java/kr/ssok/ssokopenbanking/SsokopenbankingApplication.java
+++ b/src/main/java/kr/ssok/ssokopenbanking/SsokopenbankingApplication.java
@@ -2,8 +2,10 @@ package kr.ssok.ssokopenbanking;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@EnableFeignClients
 public class SsokopenbankingApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/kr/ssok/ssokopenbanking/account/controller/AccountController.java
+++ b/src/main/java/kr/ssok/ssokopenbanking/account/controller/AccountController.java
@@ -1,4 +1,16 @@
 package kr.ssok.ssokopenbanking.account.controller;
 
+import kr.ssok.ssokopenbanking.account.service.AccountServiceImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/openbank")
 public class AccountController {
+
+    private final AccountServiceImpl accountServiceImpl;
+
+
 }

--- a/src/main/java/kr/ssok/ssokopenbanking/account/service/AccountService.java
+++ b/src/main/java/kr/ssok/ssokopenbanking/account/service/AccountService.java
@@ -1,0 +1,5 @@
+package kr.ssok.ssokopenbanking.account.service;
+
+public interface AccountService {
+
+}

--- a/src/main/java/kr/ssok/ssokopenbanking/account/service/AccountServiceImpl.java
+++ b/src/main/java/kr/ssok/ssokopenbanking/account/service/AccountServiceImpl.java
@@ -1,0 +1,14 @@
+package kr.ssok.ssokopenbanking.account.service;
+
+import kr.ssok.ssokopenbanking.global.client.BankServiceClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AccountServiceImpl implements AccountService {
+
+    private final BankServiceClient bankServiceClient;
+
+
+}

--- a/src/main/java/kr/ssok/ssokopenbanking/global/client/BankServiceClient.java
+++ b/src/main/java/kr/ssok/ssokopenbanking/global/client/BankServiceClient.java
@@ -1,0 +1,40 @@
+package kr.ssok.ssokopenbanking.global.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(name="bank-service")
+public interface BankServiceClient {
+
+    // 계좌 조회 API
+    @GetMapping("/api/bank/account")
+    ResponseEntity<BankAccountReadResponseDto> readAccount(@RequestBody BankAccountReadRequestDto requestDto);
+
+    // 계좌 실명 조회 API (예금주명 조회)
+    @GetMapping("/api/bank/account/owner")
+    ResponseEntity<BankAccountOwnerReadResponseDto> readAccountOwner(@RequestBody BankAccountOwnerReadRequestDto requestDto);
+
+    // 계좌 유효성 검사 API
+    @GetMapping("/api/bank/account/valid")
+    ResponseEntity<BankAccountValidCheckResponseDto> chekAccountValid(@RequestBody BankAccountValidCheckRequestDto requestDto);
+
+    // 휴면 계좌 여부 검사 API
+    @GetMapping("/api/bank/account/dormant")
+    ResponseEntity<BankAccountDormantCheckResponseDto> checkAccountDormant(@RequestBody BankAccountDormantCheckRequestDto requestDto);
+
+    // 계좌 잔액 조회 API (잔액 조건 검사)
+    @GetMapping("/api/bank/account/balance")
+    ResponseEntity<BankAccountBalnaceCheckResponseDto> checkAccountBalance(@RequestBody BankAccountCheckBalanceRequestDto requestDto);
+
+    // 출금 이체 API
+    @PostMapping("/api/bank/transfer/withdraw")
+    ResponseEntity<BankTransferWithDrawResponseDto> withdraw(@RequestBody BankTransferWithDrawRequestDto requestDto);
+
+    // 입금 이체 API
+    @PostMapping("/api/bank/transfer/deposit")
+    ResponseEntity<BankTransferDepositResponseDto> deposit(@RequestBody BankTransferDepositRequestDto requestDto);
+
+}


### PR DESCRIPTION
## #️⃣ Issue Number

close #2

## 📝 요약(Summary)

- 오픈뱅킹 측 계좌 개설 API 삭제 => 구현 X 결정
- openFeign 관련 초기 설정
  - 의존성 추가
  - 메인클래스에 @EnableFeignClients 추가
  - global 패키지에 client, dto 패키지 추가
    - client 패키지: feignClient 인터페이스 (뱅킹 서비스)
    - dto 패키지: 뱅킹 서비스의 API를 이용할 때 요청/응답 구조에 사용할 DTO

## 📸스크린샷 (선택)
