### PR TITLE
refactor: 계좌 도메인 api 응답 및 dto 수정 (#14, SCRUM-133)

### DIFF
--- a/src/main/java/kr/ssok/ssokopenbanking/account/controller/AccountController.java
+++ b/src/main/java/kr/ssok/ssokopenbanking/account/controller/AccountController.java
@@ -4,6 +4,7 @@ import kr.ssok.ssokopenbanking.account.dto.request.AccountBalanceReadRequestDto;
 import kr.ssok.ssokopenbanking.account.dto.request.AccountOwnerReadRequestDto;
 import kr.ssok.ssokopenbanking.account.dto.request.AccountReadRequestDto;
 import kr.ssok.ssokopenbanking.account.dto.response.AccountBalanceInfoResultDto;
+import kr.ssok.ssokopenbanking.account.dto.response.AccountInfoDto;
 import kr.ssok.ssokopenbanking.account.dto.response.AccountInfoListResultDto;
 import kr.ssok.ssokopenbanking.account.dto.response.AccountOwnerInfoResultDto;
 import kr.ssok.ssokopenbanking.account.service.AccountServiceImpl;
@@ -12,10 +13,9 @@ import kr.ssok.ssokopenbanking.global.response.code.status.ErrorStatus;
 import kr.ssok.ssokopenbanking.global.response.code.status.SuccessStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -28,14 +28,14 @@ public class AccountController {
      * 은행별 계좌 조회 요청 API
      */
     @PostMapping("/accounts/request")
-    public ResponseEntity<ApiResponse<AccountInfoListResultDto>> readAllAccounts(AccountReadRequestDto requestDto) {
+    public ResponseEntity<ApiResponse<List<AccountInfoDto>>> readAllAccounts(@RequestBody AccountReadRequestDto requestDto) {
 
-        AccountInfoListResultDto accountInfos = accountServiceImpl.readAllAccounts(requestDto);
+        List<AccountInfoDto> accountInfos = accountServiceImpl.readAllAccounts(requestDto);
 
         if (accountInfos != null) {
             return ApiResponse.success(SuccessStatus.ACCOUNT_READ_SUCCESS, accountInfos).toResponseEntity();
         } else {
-            return ApiResponse.<AccountInfoListResultDto>error(ErrorStatus.ACCOUNT_READ_FAILED).toResponseEntity();
+            return ApiResponse.<List<AccountInfoDto>>error(ErrorStatus.ACCOUNT_READ_FAILED).toResponseEntity();
         }
     }
 
@@ -43,7 +43,7 @@ public class AccountController {
      * 계좌 잔액 조회 요청 API
      */
     @PostMapping("/account/balance")
-    public ResponseEntity<ApiResponse<AccountBalanceInfoResultDto>> readBalance(AccountBalanceReadRequestDto requestDto) {
+    public ResponseEntity<ApiResponse<AccountBalanceInfoResultDto>> readBalance(@RequestBody AccountBalanceReadRequestDto requestDto) {
 
         AccountBalanceInfoResultDto accountBalanceInfo = accountServiceImpl.readAccountBalance(requestDto);
 
@@ -58,7 +58,7 @@ public class AccountController {
      * 계좌 실명 조회 요청 API
      */
     @PostMapping("/account/verify-name")
-    public ResponseEntity<ApiResponse<AccountOwnerInfoResultDto>> readAccountOwner(AccountOwnerReadRequestDto requestDto) {
+    public ResponseEntity<ApiResponse<AccountOwnerInfoResultDto>> readAccountOwner(@RequestBody AccountOwnerReadRequestDto requestDto) {
 
         AccountOwnerInfoResultDto accountOwnerInfo = accountServiceImpl.readAccountOwner(requestDto);
 

--- a/src/main/java/kr/ssok/ssokopenbanking/account/dto/request/AccountBalanceReadRequestDto.java
+++ b/src/main/java/kr/ssok/ssokopenbanking/account/dto/request/AccountBalanceReadRequestDto.java
@@ -11,5 +11,5 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class AccountBalanceReadRequestDto {
     private String accountNumber;
-    private String bankCode;
+    private int bankCode;
 }

--- a/src/main/java/kr/ssok/ssokopenbanking/account/dto/request/AccountOwnerReadRequestDto.java
+++ b/src/main/java/kr/ssok/ssokopenbanking/account/dto/request/AccountOwnerReadRequestDto.java
@@ -11,5 +11,5 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class AccountOwnerReadRequestDto {
     private String accountNumber;
-    private String bankCode;
+    private int bankCode;
 }

--- a/src/main/java/kr/ssok/ssokopenbanking/account/service/AccountService.java
+++ b/src/main/java/kr/ssok/ssokopenbanking/account/service/AccountService.java
@@ -4,12 +4,15 @@ import kr.ssok.ssokopenbanking.account.dto.request.AccountBalanceReadRequestDto;
 import kr.ssok.ssokopenbanking.account.dto.request.AccountOwnerReadRequestDto;
 import kr.ssok.ssokopenbanking.account.dto.request.AccountReadRequestDto;
 import kr.ssok.ssokopenbanking.account.dto.response.AccountBalanceInfoResultDto;
+import kr.ssok.ssokopenbanking.account.dto.response.AccountInfoDto;
 import kr.ssok.ssokopenbanking.account.dto.response.AccountInfoListResultDto;
 import kr.ssok.ssokopenbanking.account.dto.response.AccountOwnerInfoResultDto;
 
+import java.util.List;
+
 public interface AccountService {
 
-    AccountInfoListResultDto readAllAccounts(AccountReadRequestDto requestDto);
+    List<AccountInfoDto> readAllAccounts(AccountReadRequestDto requestDto);
     AccountBalanceInfoResultDto readAccountBalance(AccountBalanceReadRequestDto requestDto);
     AccountOwnerInfoResultDto readAccountOwner(AccountOwnerReadRequestDto requestDto);
 

--- a/src/main/java/kr/ssok/ssokopenbanking/account/service/AccountServiceImpl.java
+++ b/src/main/java/kr/ssok/ssokopenbanking/account/service/AccountServiceImpl.java
@@ -35,7 +35,7 @@ public class AccountServiceImpl implements AccountService {
      * @return 계좌 정보 리스트
      */
     @Override
-    public AccountInfoListResultDto readAllAccounts(AccountReadRequestDto requestDto) {
+    public List<AccountInfoDto> readAllAccounts(AccountReadRequestDto requestDto) {
 
         // 요청
         BankAccountReadRequestDto bankRequestDto = BankAccountReadRequestDto.builder()
@@ -59,10 +59,12 @@ public class AccountServiceImpl implements AccountService {
                             .accountTypeCode(account.getAccountTypeCode())
                             .build())
                     .toList();
+            /*
             AccountInfoListResultDto resultDto = AccountInfoListResultDto.builder()
                     .accounts(accounts)
                     .build();
-            return resultDto;
+             */
+            return accounts;
         } catch (CustomException e) {
             log.error("[계좌 목록 조회 실패] 비즈니스 예외 발생 - 사유: {}", e.getMessage());
             return null;


### PR DESCRIPTION
## #️⃣ Issue Number

close #14 

## 📝 요약(Summary)

- 계좌 목록 조회 api 응답 수정
  - result에 `accounts: ` 대신 바로 리스트를 반환
- 계좌 도메인 DTO의 bankCode 필드의 타입을 int로 통일
- 뱅크 서비스와의 연동 확인 완료

## 📸스크린샷 (선택)
